### PR TITLE
Refer to pytorch repository as @pytorch to allow use from other projects

### DIFF
--- a/third_party/tbb.BUILD
+++ b/third_party/tbb.BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])  # Apache 2.0
 
 template_rule(
     name = "version_string",
-    src = "@//:aten/src/ATen/cpu/tbb/extra/version_string.ver.in",
+    src = "@pytorch//:aten/src/ATen/cpu/tbb/extra/version_string.ver.in",
     out = "version_string.h",
     substitutions = {
         "@CMAKE_SYSTEM_NAME@": "Unknown",


### PR DESCRIPTION
To be consistent with the load("@pytorch//...") line above, and to allow using this build file in other projects, we can refer to the pytorch repository as @pytorch.  @ refers to the main project.